### PR TITLE
fix #24

### DIFF
--- a/Snakefile_climate_experiment
+++ b/Snakefile_climate_experiment
@@ -28,7 +28,6 @@ clim_source = config["clim_historical"]
 
 # Time horizon climate experiment
 starttime_climate = config['starttime_climate']
-endtime_climate = config['endtime_climate']
 
 # Master rule: end with all model run and analysed with saving a output plot
 rule all:
@@ -69,8 +68,8 @@ rule prepare_weagen_config:
         cftype = "generate",
         default_config = config_path,
         output_path = f"{exp_dir}/",
-        start_year = (pd.to_datetime(starttime_climate).year - 2),
-        sim_years = (pd.to_datetime(endtime_climate).year - pd.to_datetime(starttime_climate).year + 2),
+        start_year = starttime_climate,
+        sim_years = (pd.to_datetime(endtime).year - pd.to_datetime(starttime).year + 1), # + 2),
         nc_file_prefix = "rlz"
     script:
         "src/prepare_weagen_config.py"
@@ -131,8 +130,6 @@ rule downscale_climate_realization:
         toml = f"{basin_dir}/run_climate_{experiment}/wflow_sbm_rlz_"+"{rlz_num}"+"_cst_"+"{st_num2}"+".toml"
     params:
         model_dir = basin_dir,
-        starttime = starttime_climate,
-        endtime = endtime_climate,
         clim_source = clim_source,
     script:
         "src/downscale_climate_forcing.py"

--- a/config/snake_config_model_test.yml
+++ b/config/snake_config_model_test.yml
@@ -62,8 +62,7 @@ experiment_name: experiment_01
 # Number of climate realizations
 realizations_num: 3
 # Future Time horizon for the climate experiment
-starttime_climate: "2030-01-01T00:00:00"
-endtime_climate: "2050-12-31T00:00:00"
+starttime_climate: 2030
 
 # Weathergen settings
 warm.signif.level: 0.80


### PR DESCRIPTION
Update handling of time horizons for climate_experiment:

- require starttime_climate in config as a year instead of timestamp
- deducts number of year from the historical period (starttime and endtime) and starttime_climate

This changes the format of the starttime_climate argument in the snake config for climate_experiment.

Better handling of dates should avoid the overwritting of the wflow_sbm.toml config.
It was also changed by adding set_root in downscale_climate_forcing.py so that config will be written in the ouput folder directly.