### PR TITLE
add extra wflow outputs #13

### DIFF
--- a/Snakefile_climate_experiment
+++ b/Snakefile_climate_experiment
@@ -33,8 +33,8 @@ endtime_climate = config['endtime_climate']
 # Master rule: end with all model run and analysed with saving a output plot
 rule all:
     input:
-        mean = f"{exp_dir}/model_results/mean_discharge.csv",
-        #rlz_nc = expand((f"{basin_dir}/run_climate_{experiment}/output_rlz_"+"{rlz_num}"+"_cst_"+"{st_num2}"+".csv"), rlz_num=np.arange(1, RLZ_NUM+1), st_num2=np.arange(0, ST_NUM+1)),
+        mean = f"{exp_dir}/model_results/mean.csv",
+        rlz_nc = expand((f"{basin_dir}/run_climate_{experiment}/output_rlz_"+"{rlz_num}"+"_cst_"+"{st_num2}"+".csv"), rlz_num=np.arange(1, RLZ_NUM+1), st_num2=np.arange(0, ST_NUM+1)),
         #f"{exp_dir}/realization_{RLZ_NUM}/rlz_{RLZ_NUM}_historical.nc",
         #f"{exp_dir}/stress_test/cst_{ST_NUM}.csv"
 
@@ -151,10 +151,10 @@ rule export_wflow_results:
     input:
         rlz_csv_fns = expand((f"{basin_dir}/run_climate_{experiment}/output_rlz_"+"{rlz_num}"+"_cst_"+"{st_num2}"+".csv"), rlz_num=np.arange(1, RLZ_NUM+1), st_num2=np.arange(0, ST_NUM+1)),
     output:
-        mean = f"{exp_dir}/model_results/mean_discharge.csv",
-        min = f"{exp_dir}/model_results/min_discharge.csv",
-        max = f"{exp_dir}/model_results/max_discharge.csv",
-        q95 = f"{exp_dir}/model_results/q95_discharge.csv",
+        mean = f"{exp_dir}/model_results/mean.csv",
+        min = f"{exp_dir}/model_results/min.csv",
+        max = f"{exp_dir}/model_results/max.csv",
+        q95 = f"{exp_dir}/model_results/q95.csv",
     params:
         model_dir = basin_dir,
         exp_dir = exp_dir,

--- a/Snakefile_model_creation
+++ b/Snakefile_model_creation
@@ -12,6 +12,8 @@ DATA_SOURCES = config["data_sources"]
 output_locations = config["output_locations"]
 observations_timeseries = config["observations_timeseries"]
 
+wflow_outvars = config["wflow_outvars"]
+
 basin_dir = f"{project_dir}/hydrology_model"
 
 # Master rule: end with all model run and analysed with saving a output plot
@@ -31,15 +33,18 @@ rule create_model:
         """hydromt build wflow "{basin_dir}" "{model_region}" -r "{model_resolution}" -i "{input.hydromt_ini}" -d "{DATA_SOURCES}" -vv"""
 
 # Rule to add gauges to the built model
-rule add_gauges:
+rule add_gauges_and_outputs:
     input:
         basin_nc = f"{basin_dir}/staticmaps.nc"
     output:
         gauges_fid = f"{basin_dir}/staticgeoms/gauges.geojson"
     params:
-        output_locs = output_locations
-    shell:
-        """hydromt update wflow "{basin_dir}" -c setup_gauges -d "{DATA_SOURCES}" --opt gauges_fn="{params.output_locs}" --opt derive_subcatch=True -vv"""
+        output_locs = output_locations,
+        outputs = wflow_outvars,
+        data_catalog = DATA_SOURCES
+    script:
+        "src/setup_gauges_and_outputs.py"
+        #"""hydromt update wflow "{basin_dir}" -c setup_gauges -d "{DATA_SOURCES}" --opt gauges_fn="{params.output_locs}" --opt derive_subcatch=True -vv"""
 
 # Rule to prepare the time horizon
 rule setup_runtime:
@@ -86,6 +91,7 @@ rule plot_results:
        project_dir = f"{project_dir}",
        observations_file = observations_timeseries,
        gauges_output_fid = output_locations,
+       outputs = wflow_outvars,
    script: "src/plot_results.py"
 
 rule plot_map:

--- a/config/snake_config_model_test.yml
+++ b/config/snake_config_model_test.yml
@@ -18,6 +18,9 @@ endtime: "2020-12-31T00:00:00"
 # Historical climate data source (name as available in the data_sources catalog file). Either [era5, chirps_global, chirps, eobs].
 clim_historical: era5
 
+# List of wflow output variables to save
+wflow_outvars: ['river discharge', 'overland flow', 'actual evapotranspiration', 'groundwater recharge', 'snow']
+
 ###########################################################################################
 #################################### Model building #######################################
 

--- a/src/export_wflow_results.py
+++ b/src/export_wflow_results.py
@@ -28,8 +28,12 @@ mod = WflowModel(root=model_dir, mode="r")
 # Get output discharge columns
 sim = pd.read_csv(csv_fns[0], index_col=0, parse_dates=True)
 Q_vars = [x for x in sim.columns if x.startswith("Q_")]
+basavg_vars = [x for x in sim.columns if "basavg" in x]
+outvars = Q_vars.copy()
+outvars.extend(basavg_vars)
+
 col_names = ["realization", "tavg", "prcp"]
-col_names.extend(Q_vars)
+col_names.extend(outvars)
 
 df_out_mean = pd.DataFrame(
     data=np.zeros((len(csv_fns), len(col_names))),
@@ -44,7 +48,7 @@ print("Computing discharge stats for each realization/stress test")
 for i in range(len(csv_fns)):
     # Read csv file
     sim = pd.read_csv(csv_fns[i], index_col=0, parse_dates=True)
-    sim = sim[Q_vars]
+    sim = sim[outvars]
     # Get statistics
     df_mean = sim.mean()
     df_max = sim.max()

--- a/src/plot_results.py
+++ b/src/plot_results.py
@@ -15,7 +15,13 @@ import hydromt
 import os
 from hydromt_wflow import WflowModel
 
-from func_plot_signature import plot_signatures, plot_hydro, plot_hydro_1y, plot_clim
+from func_plot_signature import (
+    plot_signatures,
+    plot_hydro,
+    plot_hydro_1y,
+    plot_clim,
+    plot_basavg,
+)
 
 
 fs = 8
@@ -29,6 +35,8 @@ endtime = snakemake.params.endtime
 observations_timeseries = snakemake.params.observations_file
 gauges_output_name = snakemake.params.gauges_output_fid
 gauges_output_name = os.path.basename(gauges_output_name).split(".")[0]
+
+outputs = snakemake.params.outputs
 
 project = gauges_output_name.split("-")[-1]
 
@@ -94,6 +102,10 @@ ds_clim = xr.merge(
         mod.results["EP_subcatchment"],
     ]
 )
+
+# Other wflow outputs for wflow basin
+ds_basin = xr.merge([mod.results[dvar] for dvar in mod.results if "_basavg" in dvar])
+ds_basin = ds_basin.squeeze(drop=True)
 
 #%% Read the observations data
 # read timeseries data and match with existing gdf
@@ -235,5 +247,9 @@ for index in ds_clim.index.values:
     plot_clim(ds_clim_i, Folder_plots, f"wflow_{index}")
     plt.close()
 
+# Plots for other wflow outputs
+print("Plot basin average wflow outputs")
+plot_basavg(ds_basin, Folder_plots)
+plt.close()
 
 # TODO add summary maps mean prec and temp spatially?

--- a/src/setup_gauges_and_outputs.py
+++ b/src/setup_gauges_and_outputs.py
@@ -1,0 +1,43 @@
+import hydromt
+from hydromt_wflow import WflowModel
+import os
+
+root = os.path.dirname(snakemake.input.basin_nc)
+data_catalog = snakemake.params.data_catalog
+gauges_fn = snakemake.params.output_locs
+outputs = snakemake.params.outputs
+
+# Supported wflow outputs
+WFLOW_VARS = {
+    "river discharge": "lateral.river.q_av",
+    "overland flow": "lateral.land.q_av",
+    "actual evapotranspiration": "vertical.actevap",
+    "groundwater recharge": "vertical.recharge",
+    "snow": "vertical.snow",
+}
+
+# Instantiate wflow model
+mod = WflowModel(root, mode="r+", data_libs=data_catalog)
+
+# Add gauges
+mod.setup_gauges(
+    gauges_fn=gauges_fn,
+    derive_subcatch=True,
+)
+
+# Add additional outputs to the config
+# For now assumes basin-average timeseries apart for river.q_av which is saved by default for all outlets and gauges
+if "river discharge" in outputs:
+    outputs.remove("river discharge")
+
+for var in outputs:
+    if var in WFLOW_VARS:
+        mod.config["csv"]["column"].append(
+            {
+                "header": f"{var}_basavg",
+                "reducer": "mean",
+                "parameter": WFLOW_VARS[var],
+            }
+        )
+
+mod.write()


### PR DESCRIPTION
Adding extra output variables to the wflow run.

List of supported outputs:

- [x] overland flow
- [x] actual evapotranspiration
- [x] groundwater recharge
- [x] snow

Spatial resolution of the save:

- [x] average over the whole region/basin

Extra plots-workflow outputs produced:

- [x] historical: per month average (similar to climate plot - picture below)
- [x] stress test: points added for the surface plots in the final csv files of the climate_experiment workflow

![basin_average_outputs](https://user-images.githubusercontent.com/45457510/212632683-12147351-e248-48d2-9673-0df3e44d412d.png)
