### PR TITLE
Fix #127

### DIFF
--- a/src/func_plot_signature.py
+++ b/src/func_plot_signature.py
@@ -38,9 +38,9 @@ WFLOW_VARS = {
         "legend_annual": "groundwater recharge (mm year$^{-1}$)",
     },
     "snow": {
-        "resample": "sum",
-        "legend": "Snowpack (mm month$^{-1}$)",
-        "legend_annual": "Snowpack (mm year$^{-1}$)}",
+        "resample": "mean",
+        "legend": "Snowpack (mm)",
+        "legend_annual": "Snowpack (mm)}",
     },
 }
 


### PR DESCRIPTION
## Issue addressed
Fixes #127 

## Explanation
Snowpack is now averaged over multiple days to get the snowpack per month/year, instead of being summed. E.g., if the snowpack is 5 mm for an entire month (30 days), the snowpack during that month should be 5 mm, not 5 * 30 = 150 mm. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `delta_dates`
- [x] Tests pass locally
- [x] Black formatting pass locally
- [x] Files used by CST API and dashboard are not impacted by the changes

## Additional Notes (optional)
Snowplots need to be made again.
