### PR TITLE
pinned xarray

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,7 @@ dependencies:
   - r-ggplot2
   - r-MASS
   - r-ncdf4
-#  - r-rlang
+  #  - r-rlang
   - r-scales
   - r-sf
   - r-tibble
@@ -49,9 +49,9 @@ dependencies:
   - seaborn # plot
   - shapely>=2.0.0
   - tabulate==0.8.10 # snakemake dependency, bug in v0.9.0
-  - xarray
+  - xarray==2024.6
   - xclim
   - zarr
   - pip:
-    - hydroengine
-    - snakemake
+      - hydroengine
+      - snakemake


### PR DESCRIPTION
## Issue addressed
Xarray was causing an error with interpolating in the model build phase.  I pinned it to 2024.6 and now it works.

## Explanation
Explain how you addressed the bug/feature request, what choices you made and why.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Tests pass locally
- [ ] Black formatting pass locally
- [ ] Files used by CST API and dashboard are not impacted by the changes

## Additional Notes (optional)
Add any additional notes or information that may be helpful also if CST files were impacted.
