### PR TITLE
skip first year of basin average plots

### DIFF
--- a/src/plot_results.py
+++ b/src/plot_results.py
@@ -217,7 +217,9 @@ def analyse_wflow_historical(
 
     # If possible, skip the first year of the wflow run (warm-up period) for the basin average dataset
     if len(ds_basin.time) > 365:
-        print("Skipping the first year of the wflow run (warm-up period) in basin average variables plots")
+        print(
+            "Skipping the first year of the wflow run (warm-up period) in basin average variables plots"
+        )
         ds_basin = ds_basin.sel(
             time=slice(
                 f"{ds_basin['time.year'][0].values+1}-{ds_basin['time.month'][0].values}-{ds_basin['time.day'][0].values}",
@@ -225,7 +227,9 @@ def analyse_wflow_historical(
             )
         )
     else:
-        print("Simulation is less than a year so model warm-up period will be plotted in basin average variables.")
+        print(
+            "Simulation is less than a year so model warm-up period will be plotted in basin average variables."
+        )
 
     ### 4. Plot climate data ###
     # No plots of climate data if wflow run is less than a year


### PR DESCRIPTION
## Issue addressed
small fix to remove the first year from the basin average state and fluxes (so that the cold start it also does not influence the trends)

## Explanation
Explain how you addressed the bug/feature request, what choices you made and why.

## Checklist
- [ ] Updated tests or added new tests
- [x] Branch is up to date with `fao`
- [x] Tests pass locally
- [x] Black formatting pass locally
- [x] Files used by CST API and dashboard are not impacted by the changes

## Additional Notes (optional)
Add any additional notes or information that may be helpful also if CST files were impacted.
